### PR TITLE
[feat] 유사 Spring Security 기반 인증 추가 및 폴더 구조 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     // ✅ Spring Boot Web
     implementation 'org.springframework.boot:spring-boot-starter-web:3.5.8'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
 
     // ✅ JPA

--- a/src/main/java/com/limito/common/code/CommonErrorCode.java
+++ b/src/main/java/com/limito/common/code/CommonErrorCode.java
@@ -13,7 +13,7 @@ public enum CommonErrorCode implements ErrorCode {
 	INTERNAL_SERVER_ERROR("서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
 	// 입력값 검증
-	INVALID_INPUT("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+	BAD_REQUEST("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
 
 	// 인증/인가
 	UNAUTHORIZED("인증이 필요합니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/limito/common/code/ErrorCode.java
+++ b/src/main/java/com/limito/common/code/ErrorCode.java
@@ -3,7 +3,8 @@ package com.limito.common.code;
 import org.springframework.http.HttpStatus;
 
 public interface ErrorCode {
+	HttpStatus getStatus();
+
 	String getMessage();
 
-	HttpStatus getStatus();
 }

--- a/src/main/java/com/limito/common/exception/AppException.java
+++ b/src/main/java/com/limito/common/exception/AppException.java
@@ -11,12 +11,12 @@ public class AppException extends RuntimeException {
 
 	private final HttpStatus status;
 
-	public AppException(ErrorCode errorCode) {
+	private AppException(ErrorCode errorCode) {
 		super(errorCode.getMessage());
 		this.status = errorCode.getStatus();
 	}
 
-	public AppException(HttpStatus status, String message) {
+	private AppException(HttpStatus status, String message) {
 		super(message);
 		this.status = status;
 	}

--- a/src/main/java/com/limito/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/limito/common/exception/GlobalExceptionHandler.java
@@ -39,14 +39,18 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException exception) {
 		CommonErrorCode code = CommonErrorCode.FORBIDDEN;
 		log.error("[AccessDeniedException] {}", code.getMessage(), exception);
-		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
+		String detail = exception.getMessage();
+		String message = code.getMessage() + (detail != null ? detail : "");
+		return ErrorResponse.errorResponse(code.getStatus(), message);
 	}
 
 	@ExceptionHandler(AuthenticationException.class)
 	public ResponseEntity<ErrorResponse> handleAuthentication(AuthenticationException exception) {
 		CommonErrorCode code = CommonErrorCode.UNAUTHORIZED;
 		log.error("[AuthenticationException] {}", code.getMessage(), exception);
-		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
+		String detail = exception.getMessage();
+		String message = code.getMessage() + (detail != null ? detail : "");
+		return ErrorResponse.errorResponse(code.getStatus(), message);
 	}
 
 	// 입력값 검증
@@ -61,7 +65,9 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleValidation(Exception exception) {
 		CommonErrorCode code = CommonErrorCode.BAD_REQUEST;
 		log.error("[ValidationException] {}", code.getMessage(), exception);
-		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
+		String detail = exception.getMessage();
+		String message = code.getMessage() + (detail != null ? detail : "");
+		return ErrorResponse.errorResponse(code.getStatus(), message);
 	}
 
 	// Http 요청
@@ -70,7 +76,9 @@ public class GlobalExceptionHandler {
 		HttpRequestMethodNotSupportedException exception) {
 		CommonErrorCode code = CommonErrorCode.METHOD_NOT_ALLOWED;
 		log.error("[HttpRequestMethodNotSupportedException] {}", code.getMessage(), exception);
-		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
+		String detail = exception.getMessage();
+		String message = code.getMessage() + (detail != null ? detail : "");
+		return ErrorResponse.errorResponse(code.getStatus(), message);
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)
@@ -78,7 +86,9 @@ public class GlobalExceptionHandler {
 		HttpMessageNotReadableException exception) {
 		CommonErrorCode code = CommonErrorCode.BAD_REQUEST;
 		log.error("[HttpMessageNotReadableException] {}", code.getMessage(), exception);
-		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
+		String detail = exception.getMessage();
+		String message = code.getMessage() + (detail != null ? detail : "");
+		return ErrorResponse.errorResponse(code.getStatus(), message);
 	}
 
 	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
@@ -86,7 +96,9 @@ public class GlobalExceptionHandler {
 		HttpMediaTypeNotSupportedException exception) {
 		CommonErrorCode code = CommonErrorCode.UNSUPPORTED_MEDIA_TYPE;
 		log.error("[HttpMediaTypeNotSupportedException] {}", code.getMessage(), exception);
-		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
+		String detail = exception.getMessage();
+		String message = code.getMessage() + (detail != null ? detail : "");
+		return ErrorResponse.errorResponse(code.getStatus(), message);
 	}
 
 	// 그 외 예외처리
@@ -94,6 +106,8 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleException(Exception exception) {
 		CommonErrorCode code = CommonErrorCode.INTERNAL_SERVER_ERROR;
 		log.error("[Exception] {}", code.getMessage(), exception);
-		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
+		String detail = exception.getMessage();
+		String message = code.getMessage() + (detail != null ? detail : "");
+		return ErrorResponse.errorResponse(code.getStatus(), message);
 	}
 }

--- a/src/main/java/com/limito/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/limito/common/exception/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import java.nio.file.AccessDeniedException;
 
 import org.apache.tomcat.websocket.AuthenticationException;
 import org.hibernate.exception.ConstraintViolationException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -17,6 +16,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import com.limito.common.code.CommonErrorCode;
 import com.limito.common.response.ErrorResponse;
 
 import lombok.extern.slf4j.Slf4j;
@@ -37,18 +37,16 @@ public class GlobalExceptionHandler {
 	// 인증/인가
 	@ExceptionHandler(AccessDeniedException.class)
 	public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException exception) {
-		HttpStatus status = HttpStatus.FORBIDDEN;
-		String message = "접근 권한이 없습니다.";
-		log.error("[AccessDeniedException] {}", message, exception);
-		return ErrorResponse.errorResponse(status, message);
+		CommonErrorCode code = CommonErrorCode.FORBIDDEN;
+		log.error("[AccessDeniedException] {}", code.getMessage(), exception);
+		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
 	}
 
 	@ExceptionHandler(AuthenticationException.class)
 	public ResponseEntity<ErrorResponse> handleAuthentication(AuthenticationException exception) {
-		HttpStatus status = HttpStatus.UNAUTHORIZED;
-		String message = "인증이 필요합니다.";
-		log.error("[AuthenticationException] {}", message, exception);
-		return ErrorResponse.errorResponse(status, message);
+		CommonErrorCode code = CommonErrorCode.UNAUTHORIZED;
+		log.error("[AuthenticationException] {}", code.getMessage(), exception);
+		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
 	}
 
 	// 입력값 검증
@@ -61,49 +59,41 @@ public class GlobalExceptionHandler {
 		BindException.class
 	})
 	public ResponseEntity<ErrorResponse> handleValidation(Exception exception) {
-		HttpStatus status = HttpStatus.BAD_REQUEST;
-		String message = "요청 값이 유효하지 않습니다.";
-		log.error("[ValidationException] {}", message, exception);
-		return ErrorResponse.errorResponse(status, message);
+		CommonErrorCode code = CommonErrorCode.BAD_REQUEST;
+		log.error("[ValidationException] {}", code.getMessage(), exception);
+		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
 	}
 
 	// Http 요청
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
 	public ResponseEntity<ErrorResponse> handleMethodNotSupport(
 		HttpRequestMethodNotSupportedException exception) {
-
-		HttpStatus status = HttpStatus.METHOD_NOT_ALLOWED;
-		String message = "허용되지 않는 HTTP 메서드입니다.";
-		log.error("[HttpRequestMethodNotSupportedException] {}", message, exception);
-		return ErrorResponse.errorResponse(status, message);
+		CommonErrorCode code = CommonErrorCode.METHOD_NOT_ALLOWED;
+		log.error("[HttpRequestMethodNotSupportedException] {}", code.getMessage(), exception);
+		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ResponseEntity<ErrorResponse> handleJsonParserError(
 		HttpMessageNotReadableException exception) {
-
-		HttpStatus status = HttpStatus.BAD_REQUEST;
-		String message = "요청 본문을 읽을 수 없습니다.";
-		log.error("[HttpMessageNotReadableException] {}", message, exception);
-		return ErrorResponse.errorResponse(status, message);
+		CommonErrorCode code = CommonErrorCode.BAD_REQUEST;
+		log.error("[HttpMessageNotReadableException] {}", code.getMessage(), exception);
+		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
 	}
 
 	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
 	public ResponseEntity<ErrorResponse> handleMediaTypeNotSupport(
 		HttpMediaTypeNotSupportedException exception) {
-
-		HttpStatus status = HttpStatus.UNSUPPORTED_MEDIA_TYPE;
-		String message = "지원하지 않는 Content-Type 입니다.";
-		log.error("[HttpMediaTypeNotSupportedException] {}", message, exception);
-		return ErrorResponse.errorResponse(status, message);
+		CommonErrorCode code = CommonErrorCode.UNSUPPORTED_MEDIA_TYPE;
+		log.error("[HttpMediaTypeNotSupportedException] {}", code.getMessage(), exception);
+		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
 	}
 
 	// 그 외 예외처리
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleException(Exception exception) {
-		HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
-		String message = "서버 오류가 발생했습니다.";
-		log.error("[Exception] {}", message, exception);
-		return ErrorResponse.errorResponse(status, message);
+		CommonErrorCode code = CommonErrorCode.INTERNAL_SERVER_ERROR;
+		log.error("[Exception] {}", code.getMessage(), exception);
+		return ErrorResponse.errorResponse(code.getStatus(), code.getMessage());
 	}
 }

--- a/src/main/java/com/limito/common/response/ErrorResponse.java
+++ b/src/main/java/com/limito/common/response/ErrorResponse.java
@@ -5,13 +5,15 @@ import org.springframework.http.ResponseEntity;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ErrorResponse {
 
-	private final int status;
-	private final String message;
+	private int status;
+	private String message;
 
 	// HttpStatus + message 기반
 	public static ResponseEntity<ErrorResponse> errorResponse(HttpStatus status, String message) {

--- a/src/main/java/com/limito/common/security/CommonAutoConfiguration.java
+++ b/src/main/java/com/limito/common/security/CommonAutoConfiguration.java
@@ -1,4 +1,6 @@
-package com.limito.common.audit;
+package com.limito.common.security;
+
+import java.util.List;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -8,12 +10,20 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.Ordered;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.limito.common.security.audit.UserAuditAware;
+import com.limito.common.security.auth.CurrentUserArgResolver;
+import com.limito.common.security.auth.PreAuthorizedAspect;
+import com.limito.common.security.context.UserContextFilter;
 
 @AutoConfiguration
 @ComponentScan("com.limito.common")
 @EnableJpaAuditing
-public class CommonAutoConfiguration {
+public class CommonAutoConfiguration implements WebMvcConfigurer {
 
+	// userContextFilter 등록
 	@Bean
 	@ConditionalOnMissingBean
 	public FilterRegistrationBean<UserContextFilter> userContextFilterRegistration() {
@@ -24,9 +34,23 @@ public class CommonAutoConfiguration {
 		return registrationBean;
 	}
 
+	// JPA Auditing용 AuditorAware
 	@Bean
 	@ConditionalOnMissingBean(AuditorAware.class)
 	public AuditorAware<Long> auditorAware() {
 		return new UserAuditAware();
 	}
+
+	// @CurrentUser 읽는 ArgumentResolver 추가
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+		argumentResolvers.add(new CurrentUserArgResolver());
+	}
+
+	// @PreAuthorized 처리하는 AOP Aspect 등록
+	@Bean
+	public PreAuthorizedAspect preAuthorizedAspect() {
+		return new PreAuthorizedAspect();
+	}
+
 }

--- a/src/main/java/com/limito/common/security/audit/BaseEntity.java
+++ b/src/main/java/com/limito/common/security/audit/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.limito.common.audit;
+package com.limito.common.security.audit;
 
 import java.time.LocalDateTime;
 
@@ -7,6 +7,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.limito.common.security.context.UserContextHolder;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
@@ -42,7 +44,7 @@ public abstract class BaseEntity {
 
 	public void softDelete() {
 		this.deletedAt = LocalDateTime.now();
-		this.deletedBy = com.limito.common.audit.UserContextHolder
+		this.deletedBy = UserContextHolder
 			.getCurrentUserId()
 			.orElse(0L);
 	}

--- a/src/main/java/com/limito/common/security/audit/UserAuditAware.java
+++ b/src/main/java/com/limito/common/security/audit/UserAuditAware.java
@@ -1,9 +1,11 @@
-package com.limito.common.audit;
+package com.limito.common.security.audit;
 
 import java.util.Optional;
 
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.stereotype.Component;
+
+import com.limito.common.security.context.UserContextHolder;
 
 @Component
 public class UserAuditAware implements AuditorAware<Long> {

--- a/src/main/java/com/limito/common/security/audit/UserRole.java
+++ b/src/main/java/com/limito/common/security/audit/UserRole.java
@@ -1,4 +1,4 @@
-package com.limito.common.audit;
+package com.limito.common.security.audit;
 
 public enum UserRole {
 

--- a/src/main/java/com/limito/common/security/auth/CurrentUser.java
+++ b/src/main/java/com/limito/common/security/auth/CurrentUser.java
@@ -1,0 +1,13 @@
+package com.limito.common.security.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CurrentUser {
+}

--- a/src/main/java/com/limito/common/security/auth/CurrentUserArgResolver.java
+++ b/src/main/java/com/limito/common/security/auth/CurrentUserArgResolver.java
@@ -1,0 +1,31 @@
+package com.limito.common.security.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.limito.common.exception.AppException;
+import com.limito.common.security.context.UserContextHolder;
+
+public class CurrentUserArgResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(CurrentUser.class) && parameter.getParameterType().equals(
+			UserContextHolder.class);
+	}
+
+	@Override
+	public Object resolveArgument(
+		MethodParameter parameter,
+		ModelAndViewContainer modelAndViewContainer,
+		NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory
+	) {
+		return UserContextHolder.getCurrentUser()
+			.orElseThrow(() -> AppException.of(HttpStatus.UNAUTHORIZED, "사용자 정보가 없습니다."));
+	}
+}

--- a/src/main/java/com/limito/common/security/auth/PreAuthorized.java
+++ b/src/main/java/com/limito/common/security/auth/PreAuthorized.java
@@ -1,0 +1,16 @@
+package com.limito.common.security.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.limito.common.security.audit.UserRole;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface PreAuthorized {
+	UserRole[] value();
+}

--- a/src/main/java/com/limito/common/security/auth/PreAuthorizedAspect.java
+++ b/src/main/java/com/limito/common/security/auth/PreAuthorizedAspect.java
@@ -1,0 +1,46 @@
+package com.limito.common.security.auth;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.http.HttpStatus;
+
+import com.limito.common.exception.AppException;
+import com.limito.common.security.audit.UserRole;
+import com.limito.common.security.context.UserContextHolder;
+
+public class PreAuthorizedAspect {
+	@Around("@within(com.limito.common.security.PreAuthorized) || "
+		+ "@annotation(com.limito.common.security.PreAuthorized)")
+	public Object checkAuthorization(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+
+		MethodSignature signature = (MethodSignature)proceedingJoinPoint.getSignature();
+		Method method = signature.getMethod();
+
+		// 메서드에서 없으면 클래스에서 찾기
+		PreAuthorized preAuthorized = method.getAnnotation(PreAuthorized.class);
+		if (preAuthorized == null) {
+			preAuthorized = method.getDeclaringClass().getAnnotation(PreAuthorized.class);
+		}
+
+		// 어노테이션이 없으면 그냥 진행
+		if (preAuthorized == null) {
+			return proceedingJoinPoint.proceed();
+		}
+
+		UserRole currentRole = UserContextHolder.getCurrentUserRole()
+			.orElseThrow(() -> AppException.of(HttpStatus.UNAUTHORIZED, "사용자 정보가 없습니다."));
+
+		boolean allowed = Arrays.stream(preAuthorized.value())
+			.anyMatch(r -> r.equals(currentRole));
+
+		if (!allowed) {
+			throw AppException.of(HttpStatus.FORBIDDEN, "권한이 없습니다.");
+		}
+
+		return proceedingJoinPoint.proceed();
+	}
+}

--- a/src/main/java/com/limito/common/security/context/UserContext.java
+++ b/src/main/java/com/limito/common/security/context/UserContext.java
@@ -1,4 +1,4 @@
-package com.limito.common.audit;
+package com.limito.common.security.context;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/limito/common/security/context/UserContextFilter.java
+++ b/src/main/java/com/limito/common/security/context/UserContextFilter.java
@@ -57,7 +57,8 @@ public class UserContextFilter extends OncePerRequestFilter {
 	}
 
 	private boolean isPublicPath(String path) {
-		return path.startsWith("/api/v1/auth/signup")
+		return path.startsWith("/internal")
+			|| path.startsWith("/api/v1/auth/signup")
 			|| path.startsWith("/api/v1/auth/signup/admin")
 			|| path.startsWith("/api/v1/auth/login")
 			|| path.startsWith("/api/v1/resell-product/view")

--- a/src/main/java/com/limito/common/security/context/UserContextFilter.java
+++ b/src/main/java/com/limito/common/security/context/UserContextFilter.java
@@ -21,6 +21,13 @@ public class UserContextFilter extends OncePerRequestFilter {
 		FilterChain filterChain
 	) throws ServletException, IOException {
 
+		String path = request.getRequestURI();
+
+		if (isPublicPath(path)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
 		try {
 			// 1. 헤더에서 값 꺼내기
 			String userIdHeader = request.getHeader(HEADER_USER_ID);
@@ -47,5 +54,14 @@ public class UserContextFilter extends OncePerRequestFilter {
 			// 4. 요청 완료 시 정리
 			UserContextHolder.clear();
 		}
+	}
+
+	private boolean isPublicPath(String path) {
+		return path.startsWith("/api/v1/auth/signup")
+			|| path.startsWith("/api/v1/auth/signup/admin")
+			|| path.startsWith("/api/v1/auth/login")
+			|| path.startsWith("/api/v1/resell-product/view")
+			|| path.startsWith("/api/v1/categories")
+			|| path.startsWith("/api/v1/limited-products/view");
 	}
 }

--- a/src/main/java/com/limito/common/security/context/UserContextFilter.java
+++ b/src/main/java/com/limito/common/security/context/UserContextFilter.java
@@ -1,4 +1,4 @@
-package com.limito.common.audit;
+package com.limito.common.security.context;
 
 import java.io.IOException;
 

--- a/src/main/java/com/limito/common/security/context/UserContextHolder.java
+++ b/src/main/java/com/limito/common/security/context/UserContextHolder.java
@@ -1,6 +1,8 @@
-package com.limito.common.audit;
+package com.limito.common.security.context;
 
 import java.util.Optional;
+
+import com.limito.common.security.audit.UserRole;
 
 public final class UserContextHolder {
 
@@ -8,6 +10,14 @@ public final class UserContextHolder {
 
 	public static void set(UserContext userContext) {
 		CONTEXT.set(userContext);
+	}
+
+	public static UserContext get() {
+		return CONTEXT.get();
+	}
+
+	public static Optional<UserContext> getCurrentUser() {
+		return Optional.ofNullable(CONTEXT.get());
 	}
 
 	public static Optional<Long> getCurrentUserId() {

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,1 @@
-com.limito.common.audit.CommonAutoConfiguration
+com.limito.common.security.CommonAutoConfiguration


### PR DESCRIPTION
<!-- 템플릿 내용 -->
#7 

### 기존
- 헤더가 UserContextHolder를 세팅(UserContextFilter)
- JPA Auditing에 userId를 넣음(UserAuditAware, BaseEntity)

### 변경사항
- audit은 그대로 요청별 유저 정보와 Auditing을 담당
- auth 패키지 추가
  - @CurrentUser + @CurrentUserArgResolver가 컨트롤러에서 `@CurrentUser userContext user` 만으로 유저 정보를 주입 받음. 
  - @PreAuthroized + @PreAuthorizedAspect가 Spring Security 없이도 메서드/클래스 단위 역할 기반 권한을 체크함.
 - CommonAutoConfiguration이 Filter, Auditing, Resolver, Aspect를 한 번에 등록함.
- 파일 구조 변경
 - audit 패키지: BaseEntity, UserAuditAware, UserRole
 - auth 패키지: CurrentUser, CurrentUserArgResolver, PreAuthorized, PreAuthorizedAspect
 - context 패키지: UserContext, UserContextFilter, UserContextHolder
 - CommonAutoConfiguration 파일 
### 리뷰요청
