### PR TITLE
[fix] PreAuthorizedAspect를 Spring AOP가 관리하는 Bean으로 등록

### DIFF
--- a/src/main/java/com/limito/common/security/auth/PreAuthorizedAspect.java
+++ b/src/main/java/com/limito/common/security/auth/PreAuthorizedAspect.java
@@ -5,16 +5,20 @@ import java.util.Arrays;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
 
 import com.limito.common.exception.AppException;
 import com.limito.common.security.audit.UserRole;
 import com.limito.common.security.context.UserContextHolder;
 
+@Aspect
+@Component
 public class PreAuthorizedAspect {
-	@Around("@within(com.limito.common.security.PreAuthorized) || "
-		+ "@annotation(com.limito.common.security.PreAuthorized)")
+	@Around("@within(com.limito.common.security.auth.PreAuthorized) || "
+		+ "@annotation(com.limito.common.security.auth.PreAuthorized)")
 	public Object checkAuthorization(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
 
 		MethodSignature signature = (MethodSignature)proceedingJoinPoint.getSignature();


### PR DESCRIPTION
<!-- 템플릿 내용 -->
#12 

### 변경사항
- PreAuthorizedAspect를 Spring AOP가 관리하는 Bean으로 등록하기 위해 @Aspect, @Component 추가
-  v2.0.2 업데이트

### 리뷰요청
- 리뷰요청1